### PR TITLE
PFCORE-10064 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,25 @@ description = "tapestry-offline"
 
 repositories {
      mavenCentral()
+     maven {
+     	credentials {
+            username mavenUser
+            password mavenPassword
+        }
+        url "https://nexus.pubfactory.com/nexus/content/repositories/releases"
+     }
+     maven {
+     	credentials {
+            username mavenUser
+            password mavenPassword
+        }
+        url "https://nexus.pubfactory.com/nexus/content/repositories/snapshots"
+     }
 }
 
 dependencies {
-    compile 'org.apache.tapestry:tapestry-core:5.4.1'
-    compileOnly 'javax.servlet:servlet-api:2.5'
+    compile 'org.apache.tapestry:tapestry-core:5.2.6.3'
+    compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
     testCompile 'junit:junit:4.4'
     testCompile 'org.eclipse.jetty:jetty-webapp:7.6.17.v20150415'
 	testCompile 'org.mockito:mockito-all:1.10.19'

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.lazan</groupId>
+	<artifactId>tapestry-offline</artifactId>
+	<version>0.0.3-SNAPSHOT</version>
+	
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<configuration>
+						<source>1.8</source>
+						<target>1.8</target>
+						<release>1.8</release>
+						<encoding>UTF-8</encoding>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<configuration>
+						<encoding>UTF-8</encoding>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-project-info-reports-plugin</artifactId>
+					<version>2.9</version>
+					<configuration>
+						<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.tapestry</groupId>
+			<artifactId>tapestry-core</artifactId>
+			<version>5.2.6.3</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-webapp</artifactId>
+			<version>7.6.17.v20150415</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<distributionManagement>
+		<repository>
+			<id>ifactory-releases</id>
+			<url>https://nexus.pubfactory.com/nexus/content/repositories/releases</url>
+		</repository>
+		<snapshotRepository>
+			<id>ifactory-snapshots</id>
+			<url>https://nexus.pubfactory.com/nexus/content/repositories/snapshots</url>
+		</snapshotRepository>
+	</distributionManagement>
+</project>

--- a/src/main/java/org/lazan/t5/offline/services/TapestryOfflineModule.java
+++ b/src/main/java/org/lazan/t5/offline/services/TapestryOfflineModule.java
@@ -1,8 +1,15 @@
 package org.lazan.t5.offline.services;
 
+import java.io.IOException;
+import java.util.Collections;
 import java.util.Locale;
 
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.tapestry5.SymbolConstants;
+import org.apache.tapestry5.internal.services.CookiesImpl;
 import org.apache.tapestry5.ioc.MappedConfiguration;
 import org.apache.tapestry5.ioc.ServiceBinder;
 import org.apache.tapestry5.ioc.annotations.Contribute;
@@ -25,7 +32,10 @@ public class TapestryOfflineModule {
 	}
 	
 	@Contribute(OfflineRequestGlobals.class)
-	public void contributeOfflineRequestGlobals(MappedConfiguration<String, Object> config, ApplicationGlobals applicationGlobals, @Symbol(SymbolConstants.CHARSET) String charset) {
+	public void contributeOfflineRequestGlobals(MappedConfiguration<String, Object> config, 
+			ApplicationGlobals applicationGlobals, 
+			HttpServletRequest httpRequest,
+			@Symbol(SymbolConstants.CHARSET) String charset) {
 		config.add("locale", Locale.getDefault());
 		config.add("secure", false);
 		config.add("servletContext", applicationGlobals.getServletContext());
@@ -33,10 +43,29 @@ public class TapestryOfflineModule {
 		config.add("contentType", "text/html");
 		config.add("protocol", "http");
 		config.add("characterEncoding", charset);
+		config.add("parameterNames", httpRequest.getParameterNames());
+		config.add("requestURI", httpRequest.getRequestURI());
+		config.add("method", httpRequest.getMethod());
+		config.add("queryString", createQueryString(applicationGlobals.getServletContext()));
+		config.add("pathInfo",  httpRequest.getPathInfo());
+		config.add("cookies", httpRequest.getCookies());
+		config.add("remoteAddr", httpRequest.getRemoteAddr());
 	}
 
 	@Contribute(OfflineResponseGlobals.class)
-	public void contributeOfflineResponseGlobals(MappedConfiguration<String, Object> config, @Symbol(SymbolConstants.CHARSET) String charset) {
+	public void contributeOfflineResponseGlobals(MappedConfiguration<String, Object> config, 
+			HttpServletResponse httpResponse,
+			@Symbol(SymbolConstants.CHARSET) String charset) throws IOException {
 		config.add("characterEncoding", charset);
+		config.add("outputStream", httpResponse.getOutputStream());
+	}
+	
+	private String createQueryString(ServletContext servletContext) {
+		String[] urlParts = servletContext.getContextPath().split("\\?");
+		if (urlParts.length > 1) {
+			return new StringBuilder("?").append(urlParts[1]).toString();
+		} else {
+			return "";
+		}
 	}
 }

--- a/src/main/java/org/lazan/t5/offline/services/internal/OfflineObjectFactoryImpl.java
+++ b/src/main/java/org/lazan/t5/offline/services/internal/OfflineObjectFactoryImpl.java
@@ -7,17 +7,18 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.tapestry5.SymbolConstants;
 import org.apache.tapestry5.internal.services.RequestImpl;
 import org.apache.tapestry5.internal.services.ResponseImpl;
-import org.apache.tapestry5.internal.services.TapestrySessionFactory;
 import org.apache.tapestry5.ioc.annotations.Symbol;
 import org.apache.tapestry5.ioc.services.TypeCoercer;
 import org.apache.tapestry5.services.Request;
 import org.apache.tapestry5.services.Response;
+import org.apache.tapestry5.services.SessionPersistedObjectAnalyzer;
 import org.lazan.t5.offline.services.OfflineObjectFactory;
 import org.lazan.t5.offline.services.OfflineObjects;
 import org.lazan.t5.offline.services.OfflineResponseGlobals;
@@ -25,13 +26,13 @@ import org.lazan.t5.offline.services.OfflineResponseGlobals;
 public class OfflineObjectFactoryImpl implements OfflineObjectFactory {
 	private final OfflineResponseGlobals offlineResponseGlobals;
 	private final String requestEncoding;
-	private final TapestrySessionFactory sessionFactory;
+	private final SessionPersistedObjectAnalyzer sessionFactory;
 	private final TypeCoercer typeCoercer;
 	
 	public OfflineObjectFactoryImpl(
 			OfflineResponseGlobals offlineResponseGlobals, 
 			@Symbol(SymbolConstants.CHARSET) String requestEncoding,
-			TapestrySessionFactory sessionFactory,
+			SessionPersistedObjectAnalyzer sessionFactory,
 			TypeCoercer typeCoercer) {
 		super();
 		this.offlineResponseGlobals = offlineResponseGlobals;
@@ -75,6 +76,18 @@ public class OfflineObjectFactoryImpl implements OfflineObjectFactory {
 			@Override
 			public void write(int b) throws IOException {
 				out.write(b);
+			}
+
+			@Override
+			public boolean isReady() {
+				// TODO Auto-generated method stub
+				return false;
+			}
+
+			@Override
+			public void setWriteListener(WriteListener writeListener) {
+				// TODO Auto-generated method stub
+				
 			}
 		};
 		Map<String, Object> responseValues = new LinkedHashMap<String, Object>(offlineResponseGlobals.getValues());

--- a/src/test/java/org/lazan/t5/offline/services/internal/OfflineRequestBuilderImplTest.java
+++ b/src/test/java/org/lazan/t5/offline/services/internal/OfflineRequestBuilderImplTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
+import java.util.HashMap;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -25,7 +25,7 @@ public class OfflineRequestBuilderImplTest {
 	
 	@Test
 	public void testSession() {
-		when(requestGlobals.getValues()).thenReturn(Collections.emptyMap());
+		when(requestGlobals.getValues()).thenReturn(new HashMap<String, Object>());
 		OfflineRequestBuilder requestBuilder = new OfflineRequestBuilderImpl(requestGlobals, coercer);
 		HttpServletRequest request = requestBuilder.build();
 		

--- a/src/test/resources/org/lazan/t5/offline/demo/pages/TestPage.tml
+++ b/src/test/resources/org/lazan/t5/offline/demo/pages/TestPage.tml
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_3.xsd" xmlns:p="tapestry:parameter">
+<html lang="en" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd" xmlns:p="tapestry:parameter">
 	<body>
 		Page counting to ${pageContext} (<t:loop source="pageItems" value="currentValue">${currentValue} </t:loop>)
 		<t:block t:id="testBlock">


### PR DESCRIPTION
https://safari.atlassian.net/browse/PFCORE-10064

I had a few issues with the tapestry-offline library that ultimately lead to needing to fork this repository 

1. The latest release version 0.0.2 did not mock the httpServletRequest which ended up throwing a bunch of NPE's for us
      * Luckily it turned out there was unreleased code on the master branch that did this so I needed to fork so this could be released 
2. This library uses tapestry 5.4.1, so I needed to roll back that tapestry version to our 5.2.6.3 

Once I got that all settled I made this project a maven project so that we could build and deploy it to our nexus.  I also updated the gradle settings so that it could still be built with gradle.

Then I added it to arachne https://github.com/pubfactory/arachne/pull/30

