### PR TITLE
PFCORE-10196: Adding more complete request method implementation and making sure to handle parameters correctly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
 			<version>5.2.6.3</version>
 			<scope>compile</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.1</version>
+            <scope>compile</scope>
+        </dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>

--- a/src/main/java/org/lazan/t5/offline/services/TapestryOfflineModule.java
+++ b/src/main/java/org/lazan/t5/offline/services/TapestryOfflineModule.java
@@ -1,15 +1,12 @@
 package org.lazan.t5.offline.services;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Locale;
 
 import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.tapestry5.SymbolConstants;
-import org.apache.tapestry5.internal.services.CookiesImpl;
 import org.apache.tapestry5.ioc.MappedConfiguration;
 import org.apache.tapestry5.ioc.ServiceBinder;
 import org.apache.tapestry5.ioc.annotations.Contribute;
@@ -45,16 +42,10 @@ public class TapestryOfflineModule {
 		config.add("protocol", "http");
 		config.add("characterEncoding", charset);
 		config.add("queryString", createQueryString(applicationGlobals.getServletContext()));
-		
-		HttpServletRequest httpRequest = requestGlobals.getHTTPServletRequest();
-		if (httpRequest != null) {
-			config.add("parameterNames", httpRequest.getParameterNames());
-			config.add("requestURI", httpRequest.getRequestURI());
-			config.add("method", httpRequest.getMethod());		
-			config.add("pathInfo",  httpRequest.getPathInfo());
-			config.add("cookies", httpRequest.getCookies());
-			config.add("remoteAddr", httpRequest.getRemoteAddr());
-		}
+
+		// if you want to add info from the HttpServletRequest into the config map, do so in
+		// the arachne OfflineRenderingServiceImpl.getOfflineRequest method as it will allow
+		// null values and sometimes the request has nulls (request.getPathInfo(), etc.).
 	}
 
 	@Contribute(OfflineResponseGlobals.class)

--- a/src/main/java/org/lazan/t5/offline/services/internal/OfflineObjectFactoryImpl.java
+++ b/src/main/java/org/lazan/t5/offline/services/internal/OfflineObjectFactoryImpl.java
@@ -3,6 +3,7 @@ package org.lazan.t5.offline.services.internal;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -22,6 +23,7 @@ import org.apache.tapestry5.services.SessionPersistedObjectAnalyzer;
 import org.lazan.t5.offline.services.OfflineObjectFactory;
 import org.lazan.t5.offline.services.OfflineObjects;
 import org.lazan.t5.offline.services.OfflineResponseGlobals;
+import org.lazan.t5.offline.services.internal.ProxyBuilder.MethodHandler;
 
 public class OfflineObjectFactoryImpl implements OfflineObjectFactory {
 	private final OfflineResponseGlobals offlineResponseGlobals;
@@ -91,7 +93,18 @@ public class OfflineObjectFactoryImpl implements OfflineObjectFactory {
 			}
 		};
 		Map<String, Object> responseValues = new LinkedHashMap<String, Object>(offlineResponseGlobals.getValues());
-		responseValues.put("outputStream", servletOut);
-		return new ProxyBuilder(typeCoercer).withDefaultValues(responseValues).build(HttpServletResponse.class);
+
+        MethodHandler encodeUrlHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                return args[0];
+            }
+        };
+
+        responseValues.put("outputStream", servletOut);
+		return new ProxyBuilder(typeCoercer)
+		        .withMethodHandler("encodeURL", encodeUrlHandler)
+		        .withDefaultValues(responseValues)
+		        .build(HttpServletResponse.class);
 	}
 }

--- a/src/main/java/org/lazan/t5/offline/services/internal/OfflineRequestBuilderImpl.java
+++ b/src/main/java/org/lazan/t5/offline/services/internal/OfflineRequestBuilderImpl.java
@@ -1,13 +1,19 @@
 package org.lazan.t5.offline.services.internal;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.tapestry5.ioc.services.TypeCoercer;
 import org.lazan.t5.offline.services.OfflineRequestBuilder;
 import org.lazan.t5.offline.services.OfflineRequestGlobals;
@@ -18,7 +24,7 @@ public class OfflineRequestBuilderImpl implements OfflineRequestBuilder {
 	private Map<String, Object> sessionAttributes = new LinkedHashMap<String, Object>();
 	private Map<String, Object> headers = new LinkedHashMap<String, Object>();
 	private Map<String, Object> attributes = new LinkedHashMap<String, Object>();
-	private Map<String, String> parameters = new LinkedHashMap<String, String>();
+	private Map<String, List<String>> parameters = new LinkedHashMap<String, List<String>>();
 	
 	private final TypeCoercer typeCoercer;
 	private HttpSession session;
@@ -54,13 +60,16 @@ public class OfflineRequestBuilderImpl implements OfflineRequestBuilder {
 	
 	@Override
 	public OfflineRequestBuilder withHeader(String name, Object value) {
-		headers.put(name, value);
+		headers.put(name.toLowerCase(), value);
 		return this;
 	}
 
 	@Override
 	public OfflineRequestBuilder withParameter(String name, String value) {
-		parameters.put(name, value);
+	    if (!parameters.containsKey(name)) {
+	        parameters.put(name, new ArrayList<>());
+	    }
+		parameters.get(name).add(value);
 		return this;
 	}
 	
@@ -79,34 +88,91 @@ public class OfflineRequestBuilderImpl implements OfflineRequestBuilder {
 		MethodHandler getHeaderHandler = new MethodHandler() {
 			@Override
 			public Object handle(Method method, Object[] args) {
-				return headers.get(args[0]);
+				return headers.get(((String)args[0]).toLowerCase());
 			}
 		};
+        MethodHandler getHeaderNamesHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                return Collections.enumeration(headers.keySet());
+            }
+        };
+        MethodHandler getHeadersHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                Object value = headers.get(((String)args[0]).toLowerCase());
+                Set<Object> values = value != null ? Collections.singleton(value) : Collections.emptySet();
+                return Collections.enumeration(values);
+            }
+        };
+
 		MethodHandler getAttributeHandler = new MethodHandler() {
 			@Override
 			public Object handle(Method method, Object[] args) {
 				return attributes.get(args[0]);
 			}
 		};
+        MethodHandler getAttributeNamesHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                return Collections.enumeration(attributes.keySet());
+            }
+        };
 		MethodHandler setAttributeHandler = new MethodHandler() {
 			@Override
 			public Object handle(Method method, Object[] args) {
 				return attributes.put((String) args[0], args[1]);
 			}
 		};
+        MethodHandler removeAttributeHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                return attributes.remove((String) args[0]);
+            }
+        };
+
 		MethodHandler getParameterHandler = new MethodHandler() {
 			@Override
 			public Object handle(Method method, Object[] args) {
-				return parameters.get(args[0]);
+			    List<String> values = parameters.get(args[0]);
+			    return CollectionUtils.isEmpty(values) ? null : values.get(0);
 			}
 		};
+        MethodHandler getParameterMapHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                return parameters.entrySet().stream()
+                        .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toArray(new String[e.getValue().size()])));
+            }
+        };
+        MethodHandler getParameterNamesHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                return Collections.enumeration(parameters.keySet());
+            }
+        };
+        MethodHandler getParameterValuesHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                List<String> values = parameters.get(args[0]);
+                return values != null ? values.toArray(new String[values.size()]) : null;
+            }
+        };
+
 		MethodHandler getSessionHandler = createGetSessionHandler();
 		return new ProxyBuilder(typeCoercer)
 			.withMethodHandler("getSession", getSessionHandler)
-			.withMethodHandler("getHeader", getHeaderHandler)
-			.withMethodHandler("getParameter", getParameterHandler)
+            .withMethodHandler("getHeader", getHeaderHandler)
+            .withMethodHandler("getHeaderNames", getHeaderNamesHandler)
+            .withMethodHandler("getHeaders", getHeadersHandler)
+            .withMethodHandler("getParameter", getParameterHandler)
+            .withMethodHandler("getParameterNames", getParameterNamesHandler)
+            .withMethodHandler("getParameterValues", getParameterValuesHandler)
+            .withMethodHandler("getParameterMap", getParameterMapHandler)
 			.withMethodHandler("getAttribute", getAttributeHandler)
 			.withMethodHandler("setAttribute", setAttributeHandler)
+			.withMethodHandler("getAttributeNames", getAttributeNamesHandler)
+			.withMethodHandler("removeAttribute", removeAttributeHandler)
 			.withDefaultValues(requestValues)
 			.build(HttpServletRequest.class);
 	}
@@ -125,21 +191,35 @@ public class OfflineRequestBuilderImpl implements OfflineRequestBuilder {
 	}
 
 	private HttpSession createSession() {
-		MethodHandler getAttributeHandler = new MethodHandler() {
-			@Override
-			public Object handle(Method method, Object[] args) {
-				return sessionAttributes.get((String) args[0]);
-			}
-		};
-		MethodHandler setAttributeHandler = new MethodHandler() {
-			@Override
-			public Object handle(Method method, Object[] args) {
-				return sessionAttributes.put((String) args[0], args[1]);
-			}
-		};
+        MethodHandler getAttributeHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                return sessionAttributes.get((String) args[0]);
+            }
+        };
+        MethodHandler getAttributeNamesHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                return Collections.enumeration(sessionAttributes.keySet());
+            }
+        };
+        MethodHandler setAttributeHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                return sessionAttributes.put((String) args[0], args[1]);
+            }
+        };
+        MethodHandler removeAttributeHandler = new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                return sessionAttributes.remove((String) args[0]);
+            }
+        };
 		session = new ProxyBuilder(typeCoercer)
-				.withMethodHandler("getAttribute", getAttributeHandler)
-				.withMethodHandler("setAttribute", setAttributeHandler)
+                .withMethodHandler("getAttribute", getAttributeHandler)
+                .withMethodHandler("getAttributeNames", getAttributeNamesHandler)
+                .withMethodHandler("setAttribute", setAttributeHandler)
+                .withMethodHandler("removeAttribute", removeAttributeHandler)
 				.build(HttpSession.class);
 		return session;
 	}


### PR DESCRIPTION
This is part 1 of 3 commits to getting the probe page initialization to use tapestry-offline.

In this change I added a more complete implementation of the various parameter/header/attribute methods:
* getHeader / getHeaderNames / getHeaders
* getAttribute / getAttributeNames / setAttribute / removeAttribute
* getParameter / getParameterMap / getParameterNames / getParameterValues

I also updated the handling of parameters to be multi-values according to the HttpServletRequest API spec.

Finally, I made sure and lowercase header names as the servlet spec says header names are case-insensitive.